### PR TITLE
Extended async usage and async example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,21 @@ elif isinstance(result, BookSauce):
 ```
 *You can use the `dir` function to see all the attributes.*
 
+## Asyncio
+```python
+import asyncio
+from saucenao_api import AIOSauceNao
+
+async def main():
+    # async requesting is also supported via the AIOSauceNao class
+    async with AIOSauceNao('077f16b38a2452401790540f41246c7d951330c0') as aio:
+        results = await aio.from_url('https://i.imgur.com/k9xlw6f.jpg')
+    
+asyncio.run(main())
+```
+The async with functionality is pretty useful if you want to make multiple requests.
+Note that you can still search without the `async with` syntax by simply calling `await AIOSauceNao(...).from_url(...)`.
+
 ## Advanced usage
 ```python
 from saucenao_api import SauceNao

--- a/saucenao_api/__init__.py
+++ b/saucenao_api/__init__.py
@@ -1,5 +1,5 @@
 from .containers import BasicSauce, BookSauce, VideoSauce
-from .saucenao_api import SauceNao
+from .saucenao_api import SauceNao, AIOSauceNao
 
 __author__ = 'nomnoms12'
 __copyright__ = 'Copyright 2020, Taiga.sh Development'

--- a/saucenao_api/saucenao_api.py
+++ b/saucenao_api/saucenao_api.py
@@ -135,13 +135,13 @@ class AIOSauceNao(SauceNao):
         async with session.post(self.SAUCENAO_URL, params=params, data=files) as resp:
             status_code = resp.status
 
+            # close only if not called via 'async with AIOSauceNao(...)'
+            if not self._session:
+                await session.close()
+
             if status_code == 200:
                 parsed_resp = await resp.json()
                 raw = self._verify_response(parsed_resp, params)
-
-                # close only if not called via 'async with AIOSauceNao(...)'
-                if not self._session:
-                    await session.close()
 
                 return SauceResponse(raw)
 


### PR DESCRIPTION
Added `async with` syntax to make multiple requests easier. I've also added an async example in README.md which uses the `async with` syntax.
The `AIOSauceNao` class import was also added to \_\_init\_\_.py which allows to import the class via `from saucenao_api import AIOSauceNao`.